### PR TITLE
add mart conversions

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -21,3 +21,5 @@ models:
       +materialized: view
     intermediate:
       +materialized: view
+    marts:
+      +materialized: table

--- a/models/marts/marketing/mart_session_conversions.sql
+++ b/models/marts/marketing/mart_session_conversions.sql
@@ -1,0 +1,28 @@
+WITH sessions AS (
+    SELECT
+        session_date,
+        session_source,
+        landing_page_path,
+        device_category,
+        cv_page_path,
+        CASE WHEN is_cv THEN 1 ELSE 0 END AS cv_flag
+    FROM
+        {{ ref('int_sessions_aggregated_from_events') }}
+)
+
+SELECT
+    session_date,
+    session_source,
+    landing_page_path,
+    cv_page_path,
+    device_category,
+    COUNT(*) AS session_count,
+    SUM(cv_flag) AS cv_count
+FROM
+    sessions
+GROUP BY
+    session_date,
+    session_source,
+    landing_page_path,
+    cv_page_path,
+    device_category

--- a/models/marts/marketing/mart_session_conversions.yml
+++ b/models/marts/marketing/mart_session_conversions.yml
@@ -1,0 +1,33 @@
+---
+version: 2
+
+models:
+  - name: mart_session_conversions
+    description: "セッション日、流入元、ランディングページ、CVページ、デバイスカテゴリごとにセッション数とCV数を集計したファクトテーブル"
+    columns:
+      - name: session_date
+        description: "セッションの日付"
+        tests:
+          - not_null
+      - name: session_source
+        description: "セッションの流入元"
+        tests:
+          - not_null
+      - name: landing_page_path
+        description: "ランディングページのパス（クエリパラメータなし）"
+        tests:
+          - not_null
+      - name: cv_page_path
+        description: "CVページのパス（クエリパラメータなし）"
+      - name: device_category
+        description: "デバイスカテゴリ（mobile、desktop、tabletなど）"
+        tests:
+          - not_null
+      - name: session_count
+        description: "セッション数"
+        tests:
+          - not_null
+      - name: cv_count
+        description: "CVセッション数"
+        tests:
+          - not_null


### PR DESCRIPTION
ref: https://github.com/yrarchi/ga4_dbt_mart/issues/11

ダッシュボードでコンバージョン状況を表示させるために必要な情報を集約したテーブルをマート層に準備する。