### PR TITLE
Add permissions block for OIDC authentication in GitHub Actions

### DIFF
--- a/.github/workflows/dbt_build.yml
+++ b/.github/workflows/dbt_build.yml
@@ -12,6 +12,10 @@ jobs:
   dbt_build:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
OICD認証のためのpermissionを追加する。
```
Run google-github-actions/auth@v2
Error: google-github-actions/auth failed with: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely means the GitHub Actions workflow permissions are incorrect, or this job is being run from a fork. For more information, please see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
```