### PR TITLE
Add ci profile generation

### DIFF
--- a/.github/workflows/dbt_build.yml
+++ b/.github/workflows/dbt_build.yml
@@ -44,6 +44,22 @@ jobs:
         run: |
           echo "yesterday=$(date -u -d '1 day ago' +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
+      - name: Generate dbt profile
+        run: |
+          mkdir -p ~/.dbt
+          cat <<EOF > ~/.dbt/profiles.yml
+          ga4_dbt_mart:
+            outputs:
+              default:
+                type: bigquery
+                method: oauth
+                project: "${{ secrets.GCP_PROJECT_ID }}"
+                dataset: "${{ secrets.GA4_DATASET }}"
+                threads: 4
+                location: asia-northeast1
+            target: default
+          EOF
+
       - name: Run dbt build
         env:
           START_DATE: '20250101'


### PR DESCRIPTION
profiles.ymlがdbt buildに必要なので生成する過程を追加する。

```
Run poetry run dbt build \
Usage: dbt build [OPTIONS]
Try 'dbt build -h' for help.

Error: Invalid value for '--profiles-dir': Path '/home/runner/.dbt' does not exist.
Error: Process completed with exit code 2.
```