### PR TITLE
fix vars single quote to double quote

### DIFF
--- a/.github/workflows/dbt_build.yml
+++ b/.github/workflows/dbt_build.yml
@@ -67,7 +67,6 @@ jobs:
           GA4_DATASET: ${{ secrets.GA4_DATASET }}
         run: |
           poetry run dbt build \
-            --select stg_ga4_events \
             --vars '{
               "start_date": "${START_DATE}",
               "end_date": "${END_DATE}",

--- a/.github/workflows/dbt_build.yml
+++ b/.github/workflows/dbt_build.yml
@@ -67,8 +67,8 @@ jobs:
           GA4_DATASET: ${{ secrets.GA4_DATASET }}
         run: |
           poetry run dbt build \
-            --vars '{
+            --vars "{
               "start_date": "${START_DATE}",
               "end_date": "${END_DATE}",
               "ga4_dataset": "${GA4_DATASET}"
-            }'
+            }"


### PR DESCRIPTION
varsを囲むクオートがシングルクオートだと中の変数が文字列として認識されていそうなので、ダブルクオーとに変更してみる。

```
Database Error in model stg_ga4_events (models/staging/ga4/stg_ga4_events.sql)
  Invalid dataset ID "${GA4_DATASET}". Dataset IDs must be alphanumeric (plus underscores and dashes) and must be at most 1024 characters long.
  compiled code at target/run/ga4_dbt_mart/models/staging/ga4/stg_ga4_events.sql
02:14:50  
02:14:50  Done. PASS=0 WARN=0 ERROR=1 SKIP=2 TOTAL=3
```